### PR TITLE
Fix build warning about annotated tags.

### DIFF
--- a/wpa_supplicant/Android.mk
+++ b/wpa_supplicant/Android.mk
@@ -19,7 +19,7 @@ include $(LOCAL_PATH)/android.config
 # To ignore possible wrong network configurations
 L_CFLAGS = -DWPA_IGNORE_CONFIG_ERRORS
 
-L_CFLAGS += -DVERSION_STR_POSTFIX=\"-$(shell cd $(LOCAL_PATH) ; git describe)\"
+L_CFLAGS += -DVERSION_STR_POSTFIX=\"-$(shell cd $(LOCAL_PATH) ; git describe --tags)\"
 
 # Set Android log name
 L_CFLAGS += -DANDROID_LOG_NAME=\"wpa_supplicant\"


### PR DESCRIPTION
Currently, this error is issued 4 times at the start of a build:

fatal: No annotated tags can describe '0eb25c2a5e7441037265...
However, there were unannotated tags: try --tags.

This patch eliminates this non-lethal fatal error by adding --tags
to the git describe commands in the make files. This tag label is used
to set a CFLAGS version string for the driver.

Or, you can eliminate the error by putting in an annotated tag eg.:
git tag -a cm-10.2 -m 'eliminate error messages'
then, you don't need this patch. Or an annotated tag could be added to
the repo.

Change-Id: I388aff76df9d2e9b48da3693c89535133e7b1a35
